### PR TITLE
Cocospoon cannot be built on Java 7 because of bytecode version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>6.2.0</version>
+            <version>5.9.0</version>
         </dependency>
 
         <dependency>
@@ -45,11 +45,11 @@
             <version>1.4</version>
         </dependency>
 
-        <dependency>
+<!--        <dependency>
             <groupId>com.sanityinc</groupId>
             <artifactId>jargs</artifactId>
             <version>2.0-SNAPSHOT</version>
-        </dependency>
+        </dependency>-->
 
     </dependencies>
     <repositories>

--- a/src/main/java/fil/iagl/opl/cocospoon/tools/Params.java
+++ b/src/main/java/fil/iagl/opl/cocospoon/tools/Params.java
@@ -1,8 +1,8 @@
 package fil.iagl.opl.cocospoon.tools;
 
 
-import com.sanityinc.jargs.CmdLineParser;
-import com.sanityinc.jargs.CmdLineParser.Option;
+// import com.sanityinc.jargs.CmdLineParser;
+// import com.sanityinc.jargs.CmdLineParser.Option;
 
 
 public class Params {
@@ -12,28 +12,28 @@ public class Params {
   private String classpath;
 
   public void handleArgs(String[] args) {
-    CmdLineParser parse = new CmdLineParser();
-
-    Option<String> inputSourceOption = parse.addStringOption('i', "input-path");
-    Option<String> outputSourceOption = parse.addStringOption('o', "output-path");
-    Option<String> classPathOption = parse.addStringOption('c', "classpath");
-
-    try {
-      parse.parse(args);
-    } catch (CmdLineParser.OptionException e) {
-      System.err.println(e.getMessage());
-      printUsage();
-      System.exit(2);
-    }
-
-    inputSource = parse.getOptionValue(inputSourceOption);
-    outputSource = parse.getOptionValue(outputSourceOption);
-    classpath = parse.getOptionValue(classPathOption);
-
-    if (inputSource == null || outputSource == null) {
-      printUsage();
-      System.exit(2);
-    }
+//     CmdLineParser parse = new CmdLineParser();
+// 
+//     Option<String> inputSourceOption = parse.addStringOption('i', "input-path");
+//     Option<String> outputSourceOption = parse.addStringOption('o', "output-path");
+//     Option<String> classPathOption = parse.addStringOption('c', "classpath");
+// 
+//     try {
+//       parse.parse(args);
+//     } catch (CmdLineParser.OptionException e) {
+//       System.err.println(e.getMessage());
+//       printUsage();
+//       System.exit(2);
+//     }
+// 
+//     inputSource = parse.getOptionValue(inputSourceOption);
+//     outputSource = parse.getOptionValue(outputSourceOption);
+//     classpath = parse.getOptionValue(classPathOption);
+// 
+//     if (inputSource == null || outputSource == null) {
+//       printUsage();
+//       System.exit(2);
+//     }
   }
 
   private void printUsage() {


### PR DESCRIPTION
Cocospoon cannot be built on Java 7. 

     $ export JAVA_HOME=/opt/jdk1.7.0_10/
     $ mvn -version

```
Apache Maven 3.6.0
Maven home: /usr/share/maven
Java version: 1.7.0_10, vendor: Oracle Corporation, runtime: /home/martin/martin-no-backup/opt/jdk1.7.0_10/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.19.0-1-amd64", arch: "i386", family: "unix"
```

The reason is that it depends on com.sanityinc:jargs which is only available as Java 8 bytecode.

Solution: remove the dependency to com.sanityinc:jargs as done in this branch, but this kills the `main` method.

Then, compilation and installation succeeds: `mvn clean install -DskipTests`

The long term solution is to replace com.sanityinc:jargs by something else or to move the main method in CocoSpoon-UI.
